### PR TITLE
Fix syntax error when r_port is set

### DIFF
--- a/syncdb
+++ b/syncdb
@@ -1443,6 +1443,21 @@ then
         help
     fi
 
+    # check for extra runtime arguments
+    for i in "${@:2}"
+    do
+        case $i in
+            # disable ssh strict host key checking
+            -u|--unsecure)
+                ssh_port+="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "
+                scp_port+="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "
+            ;;
+            *)
+                    # unknown option
+            ;;
+        esac
+    done
+
 fi
 
 # script will execute whichever method is passed to it as an argument.

--- a/syncdb
+++ b/syncdb
@@ -732,7 +732,7 @@ download_remote_db () {
 
     set -o pipefail
 
-    scp -q "$scp_port"$r_user@$r_host:~/$r_web_dir/$r_bak_dir/${r_bak_name2}.bz2 .
+    scp -q $scp_port$r_user@$r_host:~/$r_web_dir/$r_bak_dir/${r_bak_name2}.bz2 .
 
     if [ $? == 0 -a -f ${r_bak_name2}.bz2 ]; then
         echo


### PR DESCRIPTION
The script crashes at "Downloading remote databases" when `r_port` is set due to the double quotes around `$scp_port` variable.

```
vagrant@dev:/var/www/$ bash --version
GNU bash, version 4.3.11(1)-release (x86_64-pc-linux-gnu)
```
